### PR TITLE
Reorder protocols on Swagger page

### DIFF
--- a/src/utils/swagger/customizePage.js
+++ b/src/utils/swagger/customizePage.js
@@ -8,10 +8,12 @@ function customizePage(req, res, next) {
     if (global.localDevelopment){
         // remove the protocol and just use the hostname
         swaggerDocument.host = global.localhost.split('//')[1]
+        swaggerDocument.schemes = ["http","https"]
     } 
     else {
         // remove the protocol and just use the hostname
         swaggerDocument.host = process.env.HEROKU_HOST.split('//')[1]
+        swaggerDocument.schemes = ["https","http"]
     }
 
     req.swaggerDoc = swaggerDocument;

--- a/src/utils/swagger/customizePage.test.js
+++ b/src/utils/swagger/customizePage.test.js
@@ -1,0 +1,41 @@
+const expect  = require('chai').expect;
+const sinon = require('sinon')
+const { mockReq, mockRes,  } = require('sinon-express-mock');
+
+const customizePage = require('./customizePage')
+const appPackage = require('../../../package.json')
+
+describe('customizePage()', () => {
+    it(`should check Swagger page is configured correctly when running locally`, async () => {
+        global.localDevelopment = true
+        global.localhost = 'http://localhost:1234'
+
+        const req = mockReq()
+        const res = mockRes()
+        const next = sinon.spy()
+
+        customizePage(req, res, next)
+
+        expect(req.swaggerDoc.info.version).to.eql(appPackage.version)
+        expect(req.swaggerDoc.host).to.eql('localhost:1234')
+        expect(req.swaggerDoc.schemes).is.an('array')
+        expect(req.swaggerDoc.schemes).eql(["http","https"])
+        sinon.restore()
+    })
+
+    it(`should check Swagger page is configured correctly when running in a hosted env`, async () => {
+        global.localDevelopment = undefined
+
+        const req = mockReq()
+        const res = mockRes()
+        const next = sinon.spy()
+
+        customizePage(req, res, next)
+
+        expect(req.swaggerDoc.info.version).to.eql(appPackage.version)
+        expect(req.swaggerDoc.host).to.eql('agora-data-aggregation.herokuapp.com/')
+        expect(req.swaggerDoc.schemes).is.an('array')
+        expect(req.swaggerDoc.schemes).eql(["https","http"])
+        sinon.restore()
+    })
+})


### PR DESCRIPTION
- Reorder protocols on Swagger page because the page now works over HTTPS instead of the previous HTTP
- Add tests for the customizePage() function